### PR TITLE
fixed bug when no .env is specified

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -158,7 +158,7 @@ func InitializeServerConfig(_ *context.Context) (*ServerConfig, error) {
 			if err = godotenv.Load(envFile); err != nil {
 				return nil, fmt.Errorf("error loading .env file (%s): %s", envFile, err.Error())
 			}
-		} else {
+		} else if isTest() {
 			return nil, fmt.Errorf("error finding .env file (%s): %s", envFile, err.Error())
 		}
 	}


### PR DESCRIPTION
This pull request updates the environment file loading logic in the `InitializeServerConfig` function. Now, when the `.env` file is missing, an error is only returned if running in a test environment, preventing unnecessary failures in other environments.

- Environment file handling:
  * Updated `InitializeServerConfig` in `internal/config/config.go` so that a missing `.env` file only causes an error in test environments, improving robustness in production and development setups.